### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: basic-openapi
+  annotations:
+    github.com/project-slug: marvin-corea-cvshealth/basic-openapi
+spec:
+  type: other
+  lifecycle: unknown
+  owner: devsecops

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,36 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: API
 metadata:
   name: basic-openapi
+  description: Basic OpenAPI example
   annotations:
     github.com/project-slug: marvin-corea-cvshealth/basic-openapi
 spec:
-  type: other
-  lifecycle: unknown
+  type: openapi
+  lifecycle: experimental
   owner: devsecops
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: Sample API
+      description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+      version: 0.1.9
+    servers:
+      - url: http://api.example.com/v1
+        description: Optional server description, e.g. Main (production) server
+      - url: http://staging-api.example.com
+        description: Optional server description, e.g. Internal staging server for testing
+    paths:
+      /users:
+        get:
+          summary: Returns a list of users.
+          description: Optional extended description in CommonMark or HTML.
+          responses:
+            '200':    # status code
+              description: A JSON array of user names
+              content:
+                application/json:
+                  schema: 
+                    type: array
+                    items: 
+                      type: string


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Tanzu Application Platform software catalog](http://tap-gui.tkgi-apps.wnp.polaris.cvshealthcloud.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).